### PR TITLE
[WIP] Simplify and fix one-hot encoding

### DIFF
--- a/niteshade/attack.py
+++ b/niteshade/attack.py
@@ -182,7 +182,7 @@ class RandomAttacker(ChangeLabelAttacker):
         og_y = y # remember orignal y
         
         if self.one_hot:
-            y = utils.decode_one_hot(y)  
+            y = y.argmax(-1)[:, np.newaxis]
 
         unique_labels = np.unique(y)
         
@@ -238,7 +238,7 @@ class AddLabeledPointsAttacker(AddPointsAttacker):
         og_y = y # remember orignal y
         
         if self.one_hot:
-            y = utils.decode_one_hot(y)
+            y = y.argmax(-1)[:, np.newaxis]
             
         num_to_add = super().num_pts_to_add(x)
         x_add = super().pick_data_to_add(x, num_to_add)
@@ -299,8 +299,8 @@ class LabelFlipperAttacker(ChangeLabelAttacker):
         og_y = y
         
         if self.one_hot:
-            y = utils.decode_one_hot(y)
-        
+            y = y.argmax(-1)[:, np.newaxis]
+
         if random.random() < self.aggressiveness:
             for i in range(len(y)):
                 element = y[i]
@@ -473,7 +473,7 @@ class BrewPoison(PerturbPointsAttacker):
             
             # decode if needed
             if self.one_hot:
-                y = utils.decode_one_hot(y)
+                y = y.argmax(-1)[:, np.newaxis]
             
             # convert to tensors if needed
             was_ndarray = False

--- a/niteshade/defence.py
+++ b/niteshade/defence.py
@@ -634,7 +634,7 @@ def _label_encoding(one_hot_labels):
         Return:
             encoded_labels (float): label data
         """
-        encoded_labels = np.argmax(one_hot_labels, axis = 1) #encode labels
+        encoded_labels = one_hot_labels.argmax(-1) #encode labels
         return encoded_labels
 
 def _input_validation(defender):

--- a/niteshade/simulation.py
+++ b/niteshade/simulation.py
@@ -145,6 +145,7 @@ class Simulator():
         self.training_points = 0
         self.original_points = 0
         self._num_modified = 0
+        self.num_defended = 0
         
         #if there is no attacker there wont be any poisoned points
         self.not_poisoned = 0

--- a/niteshade/utils.py
+++ b/niteshade/utils.py
@@ -20,6 +20,7 @@ import numpy as np
 import torchvision
 import torchvision.transforms as transforms
 import torch
+import torch.nn.functional
 from sklearn.utils import shuffle
 from sklearn.datasets import load_iris
 from sklearn.model_selection import train_test_split
@@ -134,13 +135,10 @@ def one_hot_encoding(y, num_classes):
     Returns:
         enc_y (np.array or torch.tensor) : encoded labels
     """
-    enc_y = np.zeros([np.shape(y)[0], num_classes])
-
-    for i in range(np.shape(y)[0]):
-        element = y[i]
-        enc_y[i][int(element)] = 1
-        
-    return enc_y
+    return torch.nn.functional.one_hot(
+        torch.from_numpy(y.T.squeeze()),
+        num_classes=num_classes
+    ).numpy()
 
 
 def check_num_of_classes(y):
@@ -180,28 +178,6 @@ def check_batch_size(y):
     check = len(np.shape(y))
     
     return check 
-    
-
-def decode_one_hot(y):
-    """Decode one hot encoded data.
-    
-    Args:
-        y (np.array, torch.tensor) : labels (encoded)
-    
-    Returns:
-        new_y (np.array, torch.tensor) : labels (decoded)
-    """
-    if check_batch_size(y) == 1:
-        y = y.reshape(1,-1)
-          
-    num_classes = np.shape(y)[1]
-    new_y = np.zeros([np.shape(y)[0], 1])
-    for i in range(num_classes):
-        y_col_current = y[:,i]
-        for j in range(np.shape(y)[0]):
-            if y_col_current[j] != 0:
-                new_y[j] = i
-    return new_y
 
 
 def train_test_iris(test_size=0.2, val_size = None, rand_state=42):

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -25,6 +25,7 @@ from niteshade.utils import train_test_iris, train_test_MNIST, train_test_cifar
 # =============================================================================
 #  Tests
 # =============================================================================
+@pytest.mark.long
 def test_point_counter_iris():
     batch_size = 1
     num_episodes = 100   
@@ -89,6 +90,7 @@ def test_point_counter_iris():
         attack_and_defence_results['training_points_total']
 
 
+@pytest.mark.long
 def test_point_counter_MNIST():
     batch_size = 32
     num_episodes = 10   

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -25,6 +25,7 @@ import numpy as np
 # =============================================================================
 #  Tests
 # =============================================================================
+@pytest.mark.long
 def test_mnist():
     """Attack and defense combinations simulations for Iris classifier."""
     batch_size = 32
@@ -35,9 +36,9 @@ def test_mnist():
     defender = FeasibleSetDefender(X_train, y_train, 2000)
     # defender = SoftmaxDefender(threshold=0.1)
     # attacker = SimpleAttacker(0.6, 1)
-    
+
     dict = {1:4, 4:1, 3:5, 5:3}
-    attacker = LabelFlipperAttacker(1, dict) 
+    attacker = LabelFlipperAttacker(1, dict)
 
     #implement attack and defense strategies through learner
     model = MNISTClassifier()
@@ -67,6 +68,8 @@ def test_mnist():
 
     wrapped_data, wrapped_models =  wrap_results(simulators)
 
+
+@pytest.mark.long
 def test_iris():
     """Attack and defense combinations simulations for Iris classifier."""
     batch_size = 5
@@ -76,7 +79,7 @@ def test_iris():
     # Instantiate necessary classes
     defender = FeasibleSetDefender(X_train, y_train, 0.5, one_hot=True)
                             #SoftmaxDefender(threshold=0.1))
-    
+
     attacker = AddLabeledPointsAttacker(0.6, 1, one_hot=True)
 
     #implement attack and defense strategies through learner
@@ -118,7 +121,7 @@ def test_attacker_arguments():
             assert arg1 == 2
             assert arg2 == 5
             return X, y
-            
+
     class TestAttacker(Attacker):
         def __init__(self):
             super().__init__()


### PR DESCRIPTION
The library currently seems to be working with floats for one-hot encoding, and was also using for for loops for it, which is not very parallelizable

This doesn't seem usual, since categorical data points should normally be represented as ints as opposed to floats, as they can be expected to be used as indices

One test is still failing: test_point_counter_iris, maybe because of some weird float use. The final assert in the test seems shows that something is wrong:
```
old
poisoned                 120
not_poisoned             120
correctly_defended        54
incorrectly_defended       3
original_points_total    120
training_points_total    183

new
poisoned                 281
not_poisoned             -41
correctly_defended       240
incorrectly_defended       0
original_points_total    120
training_points_total    181
```

would be cool if the devs took a look =))